### PR TITLE
Updated to work with current Python, Pillow, and ImageMagick

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,6 +10,7 @@
 [submodule "TSSSF/Mini Expansions"]
 	path = TSSSF/Mini Expansions
 	url = https://github.com/DieKatzchen/Mini-Expansions.git
+	branch = Multiplicity
 [submodule "TSSSF/Expansions"]
 	path = TSSSF/Expansions
 	url = https://github.com/secretshipfic/Expansions.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -3,13 +3,13 @@
 	url = https://github.com/secretshipfic/Core-Deck.git
 [submodule "TSSSF/Card Art"]
 	path = TSSSF/Card Art
-	url = https://github.com/secretshipfic/Card-Art.git
+	url = https://github.com/DieKatzchen/Card-Art.git
 [submodule "TSSSF/Ponyville University"]
 	path = TSSSF/Ponyville University
 	url = https://github.com/secretshipfic/PonyvilleUniversity.git
 [submodule "TSSSF/Mini Expansions"]
 	path = TSSSF/Mini Expansions
-	url = https://github.com/secretshipfic/Mini-Expansions.git
+	url = https://github.com/DieKatzchen/Mini-Expansions.git
 [submodule "TSSSF/Expansions"]
 	path = TSSSF/Expansions
 	url = https://github.com/secretshipfic/Expansions.git
@@ -18,4 +18,4 @@
 	url = https://github.com/secretshipfic/ExtraCredit.git
 [submodule "TSSSF/resources"]
 	path = TSSSF/resources
-	url = https://github.com/secretshipfic/TSSSFTemplates.git
+	url = https://github.com/DieKatzchen/TSSSFTemplates.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,12 +1,21 @@
-[submodule "Mini Expansions"]
-	path = TSSSF
-	url = https://github.com/DieKatzchen/Mini-Expansions.git
-[submodule "Core Deck"]
-	path = TSSSF/Core-Deck
+[submodule "TSSSF/Core Deck"]
+	path = TSSSF/Core Deck
 	url = https://github.com/secretshipfic/Core-Deck.git
-[submodule "Card Art"]
+[submodule "TSSSF/Card Art"]
 	path = TSSSF/Card Art
 	url = https://github.com/DieKatzchen/Card-Art.git
-[submodule "TSSSF Templates"]
+[submodule "TSSSF/Ponyville University"]
+	path = TSSSF/Ponyville University
+	url = https://github.com/secretshipfic/PonyvilleUniversity.git
+[submodule "TSSSF/Mini Expansions"]
+	path = TSSSF/Mini Expansions
+	url = https://github.com/DieKatzchen/Mini-Expansions.git
+[submodule "TSSSF/Expansions"]
+	path = TSSSF/Expansions
+	url = https://github.com/secretshipfic/Expansions.git
+[submodule "TSSSF/Extra Credit"]
+	path = TSSSF/Extra Credit
+	url = https://github.com/secretshipfic/ExtraCredit.git
+[submodule "TSSSF/resources"]
 	path = TSSSF/resources
-	https://github.com/DieKatzchen/TSSSFTemplates.git
+	url = https://github.com/secretshipfic/TSSSFTemplates.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -3,13 +3,13 @@
 	url = https://github.com/secretshipfic/Core-Deck.git
 [submodule "TSSSF/Card Art"]
 	path = TSSSF/Card Art
-	url = https://github.com/DieKatzchen/Card-Art.git
+	url = https://github.com/secretshipfic/Card-Art.git
 [submodule "TSSSF/Ponyville University"]
 	path = TSSSF/Ponyville University
 	url = https://github.com/secretshipfic/PonyvilleUniversity.git
 [submodule "TSSSF/Mini Expansions"]
 	path = TSSSF/Mini Expansions
-	url = https://github.com/DieKatzchen/Mini-Expansions.git
+	url = https://github.com/secretshipfic/Mini-Expansions.git
 [submodule "TSSSF/Expansions"]
 	path = TSSSF/Expansions
 	url = https://github.com/secretshipfic/Expansions.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,12 @@
+[submodule "Mini Expansions"]
+	path = TSSSF
+	url = https://github.com/DieKatzchen/Mini-Expansions.git
+[submodule "Core Deck"]
+	path = TSSSF/Core-Deck
+	url = https://github.com/secretshipfic/Core-Deck.git
+[submodule "Card Art"]
+	path = TSSSF/Card Art
+	url = https://github.com/DieKatzchen/Card-Art.git
+[submodule "TSSSF Templates"]
+	path = TSSSF/resources
+	https://github.com/DieKatzchen/TSSSFTemplates.git

--- a/GameGen.py
+++ b/GameGen.py
@@ -110,9 +110,9 @@ def main(folder="TSSSF", filepath="Core Deck/cards.json"):
     module.CompileVassalModule()
 
     print("\nCreating PDF...")
-    os.system(r'magick convert "{}\page_*.png" "{}\{}.pdf"'.format(workspace_path, output_folder, os.path.basename(card_set)))
+    os.system(r'magick convert "{}/page_*.png" "{}/{}.pdf"'.format(workspace_path, output_folder, os.path.basename(card_set)))
     print("\nCreating PDF of backs...")
-    os.system(r'magick convert "{}\backs_*.png" "{}\backs_{}.pdf"'.format(workspace_path, output_folder, os.path.basename(card_set)))
+    os.system(r'magick convert "{}/backs_*.png" "{}/backs_{}.pdf"'.format(workspace_path, output_folder, os.path.basename(card_set)))
     print("Done!")
 
 

--- a/GameGen.py
+++ b/GameGen.py
@@ -110,11 +110,9 @@ def main(folder="TSSSF", filepath="Core Deck/cards.json"):
     module.CompileVassalModule()
 
     print("\nCreating PDF...")
-    print('"{}\page_*.png" "{}\{}.pdf"'.format(workspace_path, output_folder, card_set))
-    os.system(r'convert "{}\page_*.png" "{}\{}.pdf"'.format(workspace_path, output_folder, card_set))
+    os.system(r'magick convert "{}\page_*.png" "{}\{}.pdf"'.format(workspace_path, output_folder, os.path.basename(card_set)))
     print("\nCreating PDF of backs...")
-    print('"{}\backs_*.png" "{}\backs_{}.pdf"'.format(workspace_path, output_folder, card_set))
-    os.system(r'convert "{}\backs_*.png" "{}\backs_{}.pdf"'.format(workspace_path, output_folder, card_set))
+    os.system(r'magick convert "{}\backs_*.png" "{}\backs_{}.pdf"'.format(workspace_path, output_folder, os.path.basename(card_set)))
     print("Done!")
 
 
@@ -139,7 +137,7 @@ if __name__ == '__main__':
 
     #main(args.basedir, args.set_file)
     #main('TSSSF', 'Core Deck/cards.pon')
-    #main('TSSSF', 'Mini Expansions\Multiplicity 0.0.1a\cards.json')
+    main('TSSSF', 'Mini Expansions/Multiplicity 0.0.1a/cards.json')
     #main('TSSSF', '1.1.0 Patch/cards.pon')
     #main('TSSSF', '2014 Con Exclusives/cards.pon')
     #main('TSSSF', 'BABScon 2015/cards.pon')

--- a/GameGen.py
+++ b/GameGen.py
@@ -136,7 +136,8 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     #main(args.basedir, args.set_file)
-    main('TSSSF', 'Multiplicity 0.0.1a/cards.pon')
+    #main('TSSSF', 'Core-Deck/cards.pon')
+    main('TSSSF', 'Multiplicity 0.0.1a/cards.json')
     #main('TSSSF', '1.1.0 Patch/cards.pon')
     #main('TSSSF', '2014 Con Exclusives/cards.pon')
     #main('TSSSF', 'BABScon 2015/cards.pon')

--- a/GameGen.py
+++ b/GameGen.py
@@ -10,7 +10,7 @@ from sys import exit
 import json
 
 
-def main(folder="TSSSF", filepath="Core Deck 1.1.6/cards.json"):
+def main(folder="TSSSF", filepath="Core Deck/cards.json"):
     '''
     @param folder: The base game folder where we'll be working.
         E.g. TSSSF, BaBOC
@@ -33,7 +33,7 @@ def main(folder="TSSSF", filepath="Core Deck 1.1.6/cards.json"):
     else:
         file_type = 'pon'
         if first_line == "TSSSF_CardGen":
-            print 'Warning: .pon files are DEPRECATED for TSSSF. Support for this format may be removed soon. Please use the pontojson.py converter to convert this file to JSON format.'
+            print('Warning: .pon files are DEPRECATED for TSSSF. Support for this format may be removed soon. Please use the pontojson.py converter to convert this file to JSON format.')
         module_name = first_line
         # Load Card File and strip out comments
         cards = [line for line in CardFile if not line[0] in ('#', ';', '/')]
@@ -42,7 +42,7 @@ def main(folder="TSSSF", filepath="Core Deck 1.1.6/cards.json"):
     try:
         module = __import__(module_name.strip())
     except ValueError:
-        print "Failed to load module: " + str(ValueError)
+        print("Failed to load module: " + str(ValueError))
         return
     card_set = os.path.dirname(filepath)
     if file_type == 'json':
@@ -88,7 +88,7 @@ def main(folder="TSSSF", filepath="Core Deck 1.1.6/cards.json"):
         # do that now, and set the card list to empty again
         if len(card_list) >= module.TOTAL_CARDS:
             page_num += 1
-            print "Building Page {}...".format(page_num)
+            print("Building Page {}...".format(page_num))
             BuildPage(card_list, page_num, module.PAGE_WIDTH, module.PAGE_HEIGHT, workspace_path)
             BuildBack(back_list, page_num, module.PAGE_WIDTH, module.PAGE_HEIGHT, workspace_path)
             card_list = []
@@ -102,18 +102,20 @@ def main(folder="TSSSF", filepath="Core Deck 1.1.6/cards.json"):
             card_list.append(module.BuildCard("BLANK"))
             back_list.append(module.BuildCard("BLANK"))
         page_num += 1
-        print "Building Page {}...".format(page_num)
+        print("Building Page {}...".format(page_num))
         BuildPage(card_list, page_num, module.PAGE_WIDTH, module.PAGE_HEIGHT, workspace_path)
         BuildBack(back_list, page_num, module.PAGE_WIDTH, module.PAGE_HEIGHT, workspace_path)
 
     # Build Vassal
     module.CompileVassalModule()
 
-    print "\nCreating PDF..."
-    os.system(r'convert "{}/page_*.png" "{}/{}.pdf"'.format(workspace_path, output_folder, card_set))
-    print "\nCreating PDF of backs..."
-    os.system(r'convert "{}/backs_*.png" "{}/backs_{}.pdf"'.format(workspace_path, output_folder, card_set))
-    print "Done!"
+    print("\nCreating PDF...")
+    print('"{}\page_*.png" "{}\{}.pdf"'.format(workspace_path, output_folder, card_set))
+    os.system(r'convert "{}\page_*.png" "{}\{}.pdf"'.format(workspace_path, output_folder, card_set))
+    print("\nCreating PDF of backs...")
+    print('"{}\backs_*.png" "{}\backs_{}.pdf"'.format(workspace_path, output_folder, card_set))
+    os.system(r'convert "{}\backs_*.png" "{}\backs_{}.pdf"'.format(workspace_path, output_folder, card_set))
+    print("Done!")
 
 
 if __name__ == '__main__':
@@ -136,8 +138,8 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     #main(args.basedir, args.set_file)
-    #main('TSSSF', 'Core-Deck/cards.pon')
-    main('TSSSF', 'Multiplicity 0.0.1a/cards.json')
+    #main('TSSSF', 'Core Deck/cards.pon')
+    #main('TSSSF', 'Mini Expansions\Multiplicity 0.0.1a\cards.json')
     #main('TSSSF', '1.1.0 Patch/cards.pon')
     #main('TSSSF', '2014 Con Exclusives/cards.pon')
     #main('TSSSF', 'BABScon 2015/cards.pon')

--- a/GameGen.py
+++ b/GameGen.py
@@ -70,7 +70,10 @@ def main(folder="TSSSF", filepath="Core Deck 1.1.6/cards.json"):
     module.CropPath = cropped_path
     vassal_path = CleanDirectory(path=folder + "/" + card_set, mkdir="vassal-images", rmstring="*.*")
     module.VassalPath = vassal_path
-
+    TGC_path = CleanDirectory(path=folder+"/"+card_set, mkdir="TGC-images",rmstring="*.*")
+    module.TGCPath = TGC_path
+	
+	
     # Create output directory
     output_folder = CleanDirectory(path=folder, mkdir=card_set, rmstring="*.pdf")
 
@@ -132,4 +135,21 @@ if __name__ == '__main__':
 
     args = parser.parse_args()
 
-    main(args.basedir, args.set_file)
+    #main(args.basedir, args.set_file)
+    main('TSSSF', 'Multiplicity 0.0.1a/cards.pon')
+    #main('TSSSF', '1.1.0 Patch/cards.pon')
+    #main('TSSSF', '2014 Con Exclusives/cards.pon')
+    #main('TSSSF', 'BABScon 2015/cards.pon')
+    #main('TSSSF', 'Core 1.0.5/cards.pon')
+    #main('TSSSF', 'Core 1.0.5 Delta/cards.pon')
+    #main('TSSSF', 'Core 1.1.0/cards.pon')
+    #main('TSSSF', 'Core 1.1.0 Test/cards.pon')
+    #main('TSSSF', 'Custom Card for/cards.pon')
+    #main('TSSSF', 'Extra Credit 0.10.4/cards.pon')
+    #main('TSSSF', 'Indiegogo/cards.pon')
+    #main('TSSSF', 'Patreon Expansion 1/cards.pon')
+    #main('TSSSF', 'Ponycon Panel 2015/cards.pon')
+    #main('TSSSF', 'Ponyville University 1.0.1/cards.pon')
+    #main('TSSSF', 'Ponyville University 0.0.2/cards.pon')
+    #main('TSSSF', 'Ponyville University 1.0.2/cards.pon')
+    #main('TSSSF', 'Thank You/cards.pon')

--- a/PIL_Helper.py
+++ b/PIL_Helper.py
@@ -155,7 +155,7 @@ def AddText(image, text, font, fill=(0,0,0), anchor=(0,0),
         coords_y = anchor_y - height
     
     image.paste(ImageOps.colorize(layer, (255,255,255), fill),
-                (coords_x, coords_y), layer)
+                (int(coords_x), int(coords_y)), layer)
 
     return total_text_size
 
@@ -171,11 +171,11 @@ def BuildPage(card_list, grid_width, grid_height, filename,
     w,h = card_list[0].size
     bg = Image.new("RGB", (w*grid_width, h*grid_height))
     # Add cards to the grid, top down, left to right
-    for y in xrange(grid_height):
-        for x in xrange(grid_width):
+    for y in range(grid_height):
+        for x in range(grid_width):
             card = card_list.pop(0)
-            coords = (x*(w+cut_line_width),
-                      y*(h+cut_line_width))
+            coords = (int(x*(w+cut_line_width)),
+                      int(y*(h+cut_line_width)))
             bg.paste(card, coords)
     # If there's a margin defined, add extra whitespace around the page
     # if h_margin > 0:
@@ -195,7 +195,7 @@ def BuildPage(card_list, grid_width, grid_height, filename,
     w,h = bg.size
     # TODO Add code that shrinks the bg if it's bigger than any dimension
     # of the Paper image
-    paper_image.paste(bg, ((paper_width - w)/2, (paper_height - h)/2))
+    paper_image.paste(bg, (int((paper_width - w)/2), int((paper_height - h)/2)))
     paper_image.save(filename, dpi=(300, 300))
 
 def BlankImage(w, h, color=(255,255,255), image_type="RGBA"):

--- a/TSSSF_CardGen.py
+++ b/TSSSF_CardGen.py
@@ -36,7 +36,7 @@ VASSAL_SCALE = (260, 359)
 VassalCard = [0]
 ART_WIDTH = 600
 base_w = 889
-base_h = 1215
+base_h = 1214
 base_w_center = base_w / 2
 base_h_center = base_h / 2
 w_marg = 31
@@ -135,30 +135,30 @@ Symbols = {
 TIMELINE_SYMBOL_LIST = ["Dystopian"]
 
 Expansions = {
-    "Everfree14": PIL_Helper.LoadImage(ExpansionIconsPath + "symbol-Everfree14.png"),
+    #"Everfree14": PIL_Helper.LoadImage(ExpansionIconsPath + "symbol-Everfree14.png"),
     "Indiegogo": PIL_Helper.LoadImage(ExpansionIconsPath + "symbol-Indiegogo.png"),
-    "Birthday": PIL_Helper.LoadImage(ExpansionIconsPath + "symbol-birthday.png"),
-    "Bronycon": PIL_Helper.LoadImage(ExpansionIconsPath + "symbol-Bronycon14.png"),
+    #"Birthday": PIL_Helper.LoadImage(ExpansionIconsPath + "symbol-birthday.png"),
+    #"Bronycon": PIL_Helper.LoadImage(ExpansionIconsPath + "symbol-Bronycon14.png"),
     "Summer": PIL_Helper.LoadImage(ExpansionIconsPath + "symbol-summer-lovin.png"),
-    "Apricity": PIL_Helper.LoadImage(ExpansionIconsPath + "symbol-apricity.png"),
-    "BronyCAN": PIL_Helper.LoadImage(ExpansionIconsPath + "symbol-Bronycan14.png"),
+    #"Apricity": PIL_Helper.LoadImage(ExpansionIconsPath + "symbol-apricity.png"),
+    #"BronyCAN": PIL_Helper.LoadImage(ExpansionIconsPath + "symbol-Bronycan14.png"),
     "Xtra": PIL_Helper.LoadImage(ExpansionIconsPath + "symbol-extracredit.png"),
-    "Xtra-dark": PIL_Helper.LoadImage(ExpansionIconsPath + "symbol-extracredit-black.png"),
-    "NMND": PIL_Helper.LoadImage(ExpansionIconsPath + "symbol-nightmarenights.png"),
-    "Ciderfest": PIL_Helper.LoadImage(ExpansionIconsPath + "symbol-ponyvilleciderfest.png"),
-    "Adventure": PIL_Helper.LoadImage(ExpansionIconsPath + "symbol-adventure.png"),
-    "Custom": PIL_Helper.LoadImage(ExpansionIconsPath + "symbol-custom.png"),
+    #"Xtra-dark": PIL_Helper.LoadImage(ExpansionIconsPath + "symbol-extracredit-black.png"),
+    #"NMND": PIL_Helper.LoadImage(ExpansionIconsPath + "symbol-nightmarenights.png"),
+    #"Ciderfest": PIL_Helper.LoadImage(ExpansionIconsPath + "symbol-ponyvilleciderfest.png"),
+    #"Adventure": PIL_Helper.LoadImage(ExpansionIconsPath + "symbol-adventure.png"),
+    #"Custom": PIL_Helper.LoadImage(ExpansionIconsPath + "symbol-custom.png"),
     "Power": PIL_Helper.LoadImage(ExpansionIconsPath + "symbol-power.png"),
     "Multiplicity": PIL_Helper.LoadImage(ExpansionIconsPath + "symbol-multiplicity.png"),
     "Canon": PIL_Helper.LoadImage(ExpansionIconsPath + "symbol-canon.png"),
-    "Dungeon": PIL_Helper.LoadImage(ExpansionIconsPath + "symbol-dungeon.png"),
+    #"Dungeon": PIL_Helper.LoadImage(ExpansionIconsPath + "symbol-dungeon.png"),
     "50": PIL_Helper.LoadImage(ExpansionIconsPath + "symbol-50.png"),
-    "2014": PIL_Helper.LoadImage(ExpansionIconsPath + "symbol-2014.png"),
-    "Hearthswarming": PIL_Helper.LoadImage(ExpansionIconsPath + "symbol-hearthswarming.png"),
-    "Ponycon 2015": PIL_Helper.LoadImage(ExpansionIconsPath + "symbol-ponynyc.png"),
-    "Patreon": PIL_Helper.LoadImage(ExpansionIconsPath + "symbol-Patreon.png"),
-    "Gameshow": PIL_Helper.LoadImage(ExpansionIconsPath + "symbol-gameshow.png"),
-    "BABScon": PIL_Helper.LoadImage(ExpansionIconsPath + "symbol-BABScon.png")
+    #"2014": PIL_Helper.LoadImage(ExpansionIconsPath + "symbol-2014.png"),
+    #"Hearthswarming": PIL_Helper.LoadImage(ExpansionIconsPath + "symbol-hearthswarming.png"),
+    #"Ponycon 2015": PIL_Helper.LoadImage(ExpansionIconsPath + "symbol-ponynyc.png"),
+    #"Patreon": PIL_Helper.LoadImage(ExpansionIconsPath + "symbol-Patreon.png"),
+    #"Gameshow": PIL_Helper.LoadImage(ExpansionIconsPath + "symbol-gameshow.png"),
+    #"BABScon": PIL_Helper.LoadImage(ExpansionIconsPath + "symbol-BABScon.png")
 }
 
 ColorDict = {

--- a/TSSSF_CardGen.py
+++ b/TSSSF_CardGen.py
@@ -34,7 +34,7 @@ VassalImagesPath = os.path.join(VassalWorkspacePath, "images")
 VASSAL_SCALE = (260, 359)
 
 VassalCard = [0]
-ART_WIDTH = 600
+ART_WIDTH = 602
 base_w = 889
 base_h = 1214
 base_w_center = base_w / 2
@@ -66,7 +66,7 @@ fonts = {
 
 Anchors = {
     "Blank": (base_w_center, 300),
-    "PonyArt": (173, 225),
+    "PonyArt": (172, 224),
     "ShipArt": (173, 226),
     "GoalArt": (174, 224),
     "Symbol1": (58 + 50, 56 + 63),

--- a/TSSSF_CardGen.py
+++ b/TSSSF_CardGen.py
@@ -301,7 +301,7 @@ def BuildCard(data):
             im_crop = im.crop(croprect)
 
     except Exception as e:
-        print "Warning, Bad Card: {0}".format(data)
+        print("Warning, Bad Card: {0}".format(data))
         traceback.print_exc()
         im_crop = MakeBlankCard().crop(croprect)
     return im_crop
@@ -388,7 +388,7 @@ def TitleText(image, text, color):
     if len(text) > TitleWidthThresholds[0]:
         anchor = Anchors["TitleSmall"]
         font = fonts["TitleSmall"]
-    print repr(text)
+    print(repr(text))
     PIL_Helper.AddText(
         image=image,
         text=text,
@@ -676,7 +676,7 @@ def MakeSpecialCard(card):
 
 
 def MakeSpecialCardJSON(data):
-    print repr(data['picture'])
+    print(repr(data['picture']))
     image = GetFrame(data['picture'])
     if data['picture'] in special_cards_with_copyright:
         CopyrightText(data, image, ColorDict["Copyright"], data.get('artist', ARTIST))
@@ -686,7 +686,7 @@ def MakeSpecialCardJSON(data):
 
 
 def MakeSpecialCardPON(data):
-    print repr(data[PICTURE])
+    print(repr(data[PICTURE]))
     image = GetFrame(data[PICTURE])
     if data[PICTURE] in special_cards_with_copyright:
         CopyrightText(data, image, ColorDict["Copyright"], ARTIST)
@@ -709,4 +709,4 @@ def CompileVassalModule():
 
 
 if __name__ == "__main__":
-    print "Not a main module. Run GameGen.py"
+    print("Not a main module. Run GameGen.py")

--- a/TSSSF_CardGen.py
+++ b/TSSSF_CardGen.py
@@ -20,6 +20,7 @@ ResourcePath = DIRECTORY + "/resources/"
 BleedsPath = DIRECTORY + "/bleed-images/"
 CropPath = DIRECTORY + "/cropped-images/"
 VassalPath = DIRECTORY + "/vassal-images/"
+TGCPath = DIRECTORY+"/TGC-images/"
 
 BleedTemplatesPath = ResourcePath + "/bleed templates/"
 SymbolsPath = ResourcePath + "/symbols/"
@@ -43,7 +44,9 @@ h_marg = 36
 baserect = [(w_marg, h_marg), (base_w - w_marg, base_h - h_marg)]
 textmaxwidth = 689
 
-croprect = (50, 63, 788 + 50, 1088 + 63)
+TGC_SCALE = (825,1125)
+
+croprect=(50,63,788+50,1088+63)
 
 TextHeightThresholds = [363, 378, 600]
 TitleWidthThresholds = [50]  # This is in #characters, fix later plox
@@ -288,7 +291,9 @@ def BuildCard(data):
             else:
                 filename = FixFileName(card_type + "_" + picture)
             SaveCard(os.path.join(BleedsPath, filename), im)
-            im_crop = im.crop(croprect)
+            im_TGC=PIL_Helper.ResizeImage(im, TGC_SCALE)
+            SaveCard(os.path.join(TGCPath, filename), im_TGC)
+            im_crop=im.crop(croprect)
             SaveCard(os.path.join(CropPath, filename), im_crop)
             im_vassal = PIL_Helper.ResizeImage(im_crop, VASSAL_SCALE)
             SaveCard(os.path.join(VassalPath, filename), im_vassal)


### PR DESCRIPTION
Brought CardMachine screaming into the modern age. Replaced all print functions to work with Python 3, cast some float coordinates as ints to work with Pillow, updated the PDF creation command to use 'magick convert' instead of 'convert' (and also fixed the command to handle subdirectories properly). In addition, I've added all the other necessary repositories as submodules, note that secretshipfic/Card-Art#2 and secretshipfic/TSSSFTemplates#3 are necessary for this to work.